### PR TITLE
Add Flask dependency to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Flask>=2.3,<3.0
 requests>=2.31,<3.0
 xlrd==1.2.0
 openpyxl>=3.0.0


### PR DESCRIPTION
## Summary
- add Flask to the dependency list so the Flask-based entrypoint can run without import errors

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce73904054832590c51fa902f882b1