### PR TITLE
Read port from environment for Flask entrypoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 from flask import Flask, jsonify, request
 from flask.typing import ResponseReturnValue
 
@@ -45,4 +47,5 @@ def index() -> ResponseReturnValue:
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=8000)
+    port = int(os.environ.get("PORT", "8000"))
+    app.run(host="0.0.0.0", port=port)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 from flask import Flask, jsonify, request
 from flask.typing import ResponseReturnValue
 
@@ -27,4 +29,5 @@ def index() -> ResponseReturnValue:
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=8000)
+    port = int(os.environ.get("PORT", "8000"))
+    app.run(host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- update the Flask entry points to read the listening port from the PORT environment variable with a default of 8000

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'texts')*

------
https://chatgpt.com/codex/tasks/task_e_68ce7bba993c83259c660168fb973971